### PR TITLE
droit d accise alcool

### DIFF
--- a/openfisca_france_indirect_taxation/model/droit_d_accise_alcool.py
+++ b/openfisca_france_indirect_taxation/model/droit_d_accise_alcool.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+# OpenFisca -- A versatile microsimulation software
+# By: OpenFisca Team <contact@openfisca.fr>
+#
+# Copyright (C) 2011, 2012, 2013, 2014 OpenFisca Team
+# https://github.com/openfisca
+#
+# This file is part of OpenFisca.
+#
+# OpenFisca is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# OpenFisca is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def montant_droit_d_accise_alcool(taux, depense):
+    """
+    Calcule le montant de droit d'accise sur un volume de dépense payé pour le poste adéquat
+    """
+    return depense*taux/(1+taux)
+

--- a/openfisca_france_indirect_taxation/model/output_variables.py
+++ b/openfisca_france_indirect_taxation/model/output_variables.py
@@ -32,10 +32,14 @@ from ..entities import Individus
 from openfisca_france_indirect_taxation import reference_formula
 
 from openfisca_france_indirect_taxation.model.tva import montant_tva
+from openfisca_france_indirect_taxation.model.droit_d_accise_alcool import montant_droit_d_accise_alcool
 from openfisca_france_indirect_taxation.param.param import P_tva_taux_plein
 from openfisca_france_indirect_taxation.param.param import P_tva_taux_intermediaire
 from openfisca_france_indirect_taxation.param.param import P_tva_taux_reduit
 from openfisca_france_indirect_taxation.param.param import P_tva_taux_super_reduit
+from openfisca_france_indirect_taxation.param.param import P_alcool_0211
+from openfisca_france_indirect_taxation.param.param import P_alcool_0212
+from openfisca_france_indirect_taxation.param.param import P_alcool_0213
 
 
 @reference_formula
@@ -76,6 +80,7 @@ class montant_tva_taux_intermediaire(SimpleFormulaColumn):
     def get_output_period(self, period):
         return period
 
+
 @reference_formula
 class montant_tva_taux_reduit(SimpleFormulaColumn):
     column = FloatCol
@@ -97,6 +102,44 @@ class montant_tva_taux_super_reduit(SimpleFormulaColumn):
 
     def function(self, consommation_tva_taux_super_reduit):
         return montant_tva(P_tva_taux_super_reduit, consommation_tva_taux_super_reduit)
+
+    def get_output_period(self, period):
+        return period
+
+@reference_formula
+class montant_droit_d_accise_alcool_0211(SimpleFormulaColumn):
+    column = FloatCol
+    entity_class = Individus
+    label = u"Montant des droits d'accises sur les alcools poste 0211"
+
+    def function(self, consommation_alcool_0211):
+        return montant_droit_d_accise_alcool(P_alcool_0211, consommation_alcool_0211)
+
+    def get_output_period(self, period):
+        return period
+
+
+@reference_formula
+class montant_droit_d_accise_alcool_0212(SimpleFormulaColumn):
+    column = FloatCol
+    entity_class = Individus
+    label = u"Montant des droits d'accises sur les alcools poste 0212"
+
+    def function(self, consommation_alcool_0212):
+        return montant_droit_d_accise_alcool(P_alcool_0212, consommation_alcool_0212)
+
+    def get_output_period(self, period):
+        return period
+
+
+@reference_formula
+class montant_droit_d_accise_alcool_0213(SimpleFormulaColumn):
+    column = FloatCol
+    entity_class = Individus
+    label = u"Montant des droits d'accises sur les alcools poste 0213"
+
+    def function(self, consommation_alcool_0213):
+        return montant_droit_d_accise_alcool(P_alcool_0213, consommation_alcool_0213)
 
     def get_output_period(self, period):
         return period

--- a/openfisca_france_indirect_taxation/param/param.py
+++ b/openfisca_france_indirect_taxation/param/param.py
@@ -7,3 +7,9 @@ P_tva_taux_plein = 0.196
 P_tva_taux_intermediaire = 0.07
 P_tva_taux_reduit = 0.055
 P_tva_taux_super_reduit = 0.021
+
+# Pour l'année 2010
+
+P_alcool_0211 = 1.73
+P_alcool_0212 = 0.02
+P_alcool_0213 = 0.41

--- a/openfisca_france_indirect_taxation/tests/test_alcool.py
+++ b/openfisca_france_indirect_taxation/tests/test_alcool.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+
+# OpenFisca -- A versatile microsimulation software
+# By: OpenFisca Team <contact@openfisca.fr>
+#
+# Copyright (C) 2011, 2012, 2013, 2014 OpenFisca Team
+# https://github.com/openfisca
+#
+# This file is part of OpenFisca.
+#
+# OpenFisca is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# OpenFisca is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import datetime
+
+from nose.tools import assert_equal
+
+from openfisca_core.tools import assert_near
+from openfisca_france_indirect_taxation.tests import base
+
+
+def test_droit_d_accise_alcool_0211():
+    year = 2010
+    simulation = base.tax_benefit_system.new_scenario().init_single_entity(
+        period = year,
+        personne_de_reference = dict(
+            birth = datetime.date(year - 40, 1, 1),
+            consommation_alcool_0211 = 100,
+            ),
+        ).new_simulation(debug = True)
+
+    assert_equal(simulation.calculate('consommation_alcool_0211'), 100)
+    assert_near(simulation.calculate('montant_droit_d_accise_alcool_0211'), 100*(1.73)/(1+1.73), .01)
+
+
+def test_droit_d_accise_alcool_0212():
+    year = 2010
+    simulation = base.tax_benefit_system.new_scenario().init_single_entity(
+        period = year,
+        personne_de_reference = dict(
+            birth = datetime.date(year - 40, 1, 1),
+            consommation_alcool_0212 = 100,
+            ),
+        ).new_simulation(debug = True)
+
+    assert_equal(simulation.calculate('consommation_alcool_0212'), 100)
+    assert_near(simulation.calculate('montant_droit_d_accise_alcool_0212'), 100*(0.02)/(1+0.02), .01)
+
+
+def test_droit_d_accise_alcool_0213():
+    year = 2010
+    simulation = base.tax_benefit_system.new_scenario().init_single_entity(
+        period = year,
+        personne_de_reference = dict(
+            birth = datetime.date(year - 40, 1, 1),
+            consommation_alcool_0213 = 100,
+            ),
+        ).new_simulation(debug = True)
+
+    assert_equal(simulation.calculate('consommation_alcool_0213'), 100)
+    assert_near(simulation.calculate('montant_droit_d_accise_alcool_0213'), 100*(0.41)/(1+0.41), .01)
+
+
+if __name__ == '__main__':
+    import logging
+    import sys
+
+    logging.basicConfig(level = logging.ERROR, stream = sys.stdout)
+    test_droit_d_accise_alcool_0211()
+    test_droit_d_accise_alcool_0212()
+    test_droit_d_accise_alcool_0213()


### PR DESCRIPTION
Bonjour,

nous avons essayé de créer le montant des droits d'accise sur l'alcool (postes 0211, 0212 et 0213) ainsi que les tests.
Pour cela, nous avons repris le modèle des taux de tva après avoir travaillé sur stata.
Pourtant, après avoir lancé nosetest et test_alcool git shell m'indique 0 tests lancés alors qu'il devrait en lancer 3.
Quelles sont mes erreurs ?
De plus, y a t'il un moyen pour simplifier le fichier output_variables pour importer en une seule ligne tous les paramètres de taux au lieu d'utiliser à chaque fois "from openfisca_france_indirect_taxation.param.param import P... " ?
